### PR TITLE
alternative way to clean the conflict of PMT with SDT/NIT/EIT in korean tv streams

### DIFF
--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -672,27 +672,22 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
         } else if (pid == DVB_SDT_PID) {
           
           dvb_table_parse(&pm->pm_sdt, "-", tsb, l, 1, 0, pass_muxer_sdt_cb);
-//          if (pid == pm->pm_pmt_pid)
-//            goto __pmt;
 
         /* NIT */
         } else if (pid == DVB_NIT_PID) {
         
           dvb_table_parse(&pm->pm_nit, "-", tsb, l, 1, 0, pass_muxer_nit_cb);
-//          if (pid == pm->pm_pmt_pid)
-//            goto __pmt;
 
         /* EIT */
         } else if (pid == DVB_EIT_PID) {
         
           dvb_table_parse(&pm->pm_eit, "-", tsb, l, 1, 0, pass_muxer_eit_cb);
-//          if (pid == pm->pm_pmt_pid)
-//            goto __pmt;
 
+        }
+        
         /* PMT */
-        } else if {
+        if (pid == pm->pm_pmt_pid) {
 
-//__pmt:
           dvb_table_parse(&pm->pm_pmt, "-", tsb, l, 1, 0, pass_muxer_pmt_cb);
 
         }

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -452,6 +452,7 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
   pm->pm_rewrite_nit = !!pm->m_config.u.pass.m_rewrite_nit;
   pm->pm_rewrite_eit = !!pm->m_config.u.pass.m_rewrite_eit;
 
+/*
   if ( (pm->pm_pmt_pid == DVB_SDT_PID || pm->pm_pmt_pid == DVB_NIT_PID || pm->pm_pmt_pid == DVB_EIT_PID) && pm->pm_rewrite_pmt) {
     tvhwarn(LS_PASS, "PMT PID shared with SDT/NIT/EIT, rewrite disabled");
     pm->pm_rewrite_pmt = 0;
@@ -468,6 +469,7 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
       pm->pm_rewrite_eit = 0;
     }
   }
+*/
 
   for(i=0; i < ss->ss_num_components; i++) {
     ssc = &ss->ss_components[i];
@@ -670,20 +672,27 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
         } else if (pid == DVB_SDT_PID) {
           
           dvb_table_parse(&pm->pm_sdt, "-", tsb, l, 1, 0, pass_muxer_sdt_cb);
+          if (pid == pm->pm_pmt_pid)
+            goto __pmt;
 
         /* NIT */
         } else if (pid == DVB_NIT_PID) {
         
           dvb_table_parse(&pm->pm_nit, "-", tsb, l, 1, 0, pass_muxer_nit_cb);
+          if (pid == pm->pm_pmt_pid)
+            goto __pmt;
 
         /* EIT */
         } else if (pid == DVB_EIT_PID) {
         
           dvb_table_parse(&pm->pm_eit, "-", tsb, l, 1, 0, pass_muxer_eit_cb);
+          if (pid == pm->pm_pmt_pid)
+            goto __pmt;
 
         /* PMT */
         } else {
 
+__pmt:
           dvb_table_parse(&pm->pm_pmt, "-", tsb, l, 1, 0, pass_muxer_pmt_cb);
 
         }

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -672,27 +672,27 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
         } else if (pid == DVB_SDT_PID) {
           
           dvb_table_parse(&pm->pm_sdt, "-", tsb, l, 1, 0, pass_muxer_sdt_cb);
-          if (pid == pm->pm_pmt_pid)
-            goto __pmt;
+//          if (pid == pm->pm_pmt_pid)
+//            goto __pmt;
 
         /* NIT */
         } else if (pid == DVB_NIT_PID) {
         
           dvb_table_parse(&pm->pm_nit, "-", tsb, l, 1, 0, pass_muxer_nit_cb);
-          if (pid == pm->pm_pmt_pid)
-            goto __pmt;
+//          if (pid == pm->pm_pmt_pid)
+//            goto __pmt;
 
         /* EIT */
         } else if (pid == DVB_EIT_PID) {
         
           dvb_table_parse(&pm->pm_eit, "-", tsb, l, 1, 0, pass_muxer_eit_cb);
-          if (pid == pm->pm_pmt_pid)
-            goto __pmt;
+//          if (pid == pm->pm_pmt_pid)
+//            goto __pmt;
 
         /* PMT */
-        } else {
+        } else if {
 
-__pmt:
+//__pmt:
           dvb_table_parse(&pm->pm_pmt, "-", tsb, l, 1, 0, pass_muxer_pmt_cb);
 
         }

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -452,25 +452,6 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
   pm->pm_rewrite_nit = !!pm->m_config.u.pass.m_rewrite_nit;
   pm->pm_rewrite_eit = !!pm->m_config.u.pass.m_rewrite_eit;
 
-/*
-  if ( (pm->pm_pmt_pid == DVB_SDT_PID || pm->pm_pmt_pid == DVB_NIT_PID || pm->pm_pmt_pid == DVB_EIT_PID) && pm->pm_rewrite_pmt) {
-    tvhwarn(LS_PASS, "PMT PID shared with SDT/NIT/EIT, rewrite disabled");
-    pm->pm_rewrite_pmt = 0;
-    if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_sdt) {
-      tvhwarn(LS_PASS, "SDT PID shared with PMT, rewrite disabled");
-      pm->pm_rewrite_sdt = 0;
-    }
-    if (pm->pm_pmt_pid == DVB_NIT_PID && pm->pm_rewrite_nit) {
-      tvhwarn(LS_PASS, "NIT PID shared with PMT, rewrite disabled");
-      pm->pm_rewrite_nit = 0;
-    }
-    if (pm->pm_pmt_pid == DVB_EIT_PID && pm->pm_rewrite_eit) {
-      tvhwarn(LS_PASS, "EIT PID shared with PMT, rewrite disabled");
-      pm->pm_rewrite_eit = 0;
-    }
-  }
-*/
-
   for(i=0; i < ss->ss_num_components; i++) {
     ssc = &ss->ss_components[i];
     if (!SCT_ISVIDEO(ssc->es_type) && !SCT_ISAUDIO(ssc->es_type))


### PR DESCRIPTION
In the `Write TS packets to the file descriptor` section, SDT, NIT, EIT and PMT were all treated parallel in `else if` structures. This is not good for cases where PMT has the same PID as SDT, NIT or EIT. For this case, it does make sense to take PMT treatment out of `else if` and put it into a separate `if`.
