### PR TITLE
Fix time for old 32bit systems

### DIFF
--- a/configure
+++ b/configure
@@ -279,6 +279,42 @@ int test(void)
 }
 '
 
+check_cc_snippet time_ld '
+#define _FILE_OFFSET_BITS 64
+#define _TIME_BITS 64
+#include <assert.h>
+#include <stdio.h>
+#include <time.h>
+#define TEST test
+int test(void)
+{
+  printf("%ld", (time_t)1);
+  return 0;
+}
+' -Werror
+
+check_cc_snippet time_lld '
+#define _FILE_OFFSET_BITS 64
+#define _TIME_BITS 64
+#include <assert.h>
+#include <stdio.h>
+#include <time.h>
+#define TEST test
+int test(void)
+{
+  printf("%lld", (time_t)1);
+  return 0;
+}
+' -Werror
+
+if enabled time_lld; then
+  printf "    ^ using time_t format 'lld'\n"
+elif enabled time_ld; then
+  printf "    ^ using time_t format 'ld'\n"
+else
+  die 'Unable to determine size of "time_t"'
+fi
+
 check_cc_snippet stime '
 #include <time.h>
 #define TEST test

--- a/src/tvheadend.h
+++ b/src/tvheadend.h
@@ -334,12 +334,12 @@ void tvh_qsort_r(void *base, size_t nmemb, size_t size, int (*compar)(const void
 # endif /* ULONG_MAX */
 #endif /* __WORDSIZE */
 
-#if __WORDSIZE == 32
+#if CONFIG_TIME_LLD == 1
 # define PRItime_t "lld"
-#elif __WORDSIZE == 64
+#elif CONFIG_TIME_LD == 1
 # define PRItime_t "ld"
 #else
-# error "__WORDSIZE not properly defined"
+# error "CONFIG_TIME not properly defined"
 #endif
 
 /* transcoding */


### PR DESCRIPTION
The fix introduced in fe47ecb5504a ("Fix time for 32bit systems again") made the incorrect assumption, that the macro _TIME_BITS=64 was always available. It seems like that this is not the case for old systems, causing 32bit builds to break there.

Lets completely rework 32bit time support, by actually detecting the hosts size for the time.

This will break cross-compilation, as the configure script is run on the host, but since we do not seem to support cross-builds anyway (all archs are build on emulated or native targets), this should be acceptable.

Fixes fe47ecb5504a ("Fix time for 32bit systems again")