### PR TITLE
Use explicitly on format warnings for Time test

### DIFF
--- a/configure
+++ b/configure
@@ -291,7 +291,7 @@ int test(void)
   printf("%ld", (time_t)1);
   return 0;
 }
-' -Werror
+' '-Wformat -Werror=format'
 
 check_cc_snippet time_lld '
 #define _FILE_OFFSET_BITS 64
@@ -305,7 +305,7 @@ int test(void)
   printf("%lld", (time_t)1);
   return 0;
 }
-' -Werror
+' '-Wformat -Werror=format'
 
 if enabled time_lld; then
   printf "    ^ using time_t format 'lld'\n"


### PR DESCRIPTION
It looks like the compile check doesn't work properly on some architectures, which appears to eat or ignore the -Werror flag.

Instead, be more specific in that we state that printf formatting errors are to be triggered on, and treated as an error explicitly, which in the end is exactly what we are after.